### PR TITLE
Fix gender check to hide game

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,6 +68,7 @@ function init() {
   const gender = localStorage.getItem("gender");
   if (!gender) {
     selectScreen.classList.remove("hidden");
+    gameScreen.classList.add("hidden");
     selectedGender = null;
     confirmBtn.disabled = true;
     document.getElementById("btn-female").classList.remove("selected");


### PR DESCRIPTION
## Summary
- when no gender is saved, also hide the game screen

## Testing
- `npx serve .` *(fails: needed packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844c2d3d8e88320b3d1497d5d7d9286